### PR TITLE
Deploy online

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # spectra
+
+Deploy online:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/DircePineda/spectra.git/HEAD)

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,2 @@
+# Install packages via apt
+bash-completion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+#### pip install -r requirements.txt ####
+### Other Options ###
+## docopt == 0.6.1             # Version Matching. Must be version 0.6.1
+## keyring >= 4.1.1            # Minimum version 4.1.1
+## coverage != 3.5             # Version Exclusion. Anything except version 3.5
+## Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*
+## package >= 1.0, <=2.0       # Between ver 1.0 and 2.0
+
+## Basics
+NumPy
+pandas
+matplotlib
+scipy


### PR DESCRIPTION
Agregué 2 archivos:

- `requirements.txt` contiene la lista de los paquetes de python que requieres tener instalados.
- `apt.txt` contiene programas que requieres en tu entorno de instalación, básicamente binder funciona como un contenedor linux (ubuntu, de forma predeterminada), por lo que si requieres instalar algo en el SO solo debes listarlo desde ahí.

Con esos archivos, solo debes presionar el botón que puse en el archivo README y se replicará el entorno de desarrollo que necesitas. Estos dos archivos puedes colocarlos y modificarlos en otros proyectos para así tener siempre el entorno adecuado.

Espero te sirva para no depender de una sola plataforma.